### PR TITLE
use aws-sdk 2.1489.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "^2.6.1"
   },
   "dependencies": {
-    "aws-sdk": "2.1490.0",
+    "aws-sdk": "2.1489.0",
     "debug": "^4.1.1"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-consumer",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Build SQS-based Node applications without the boilerplate",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
packages in monday uses that version, so prevent installing aws-sdk multiple times by downgrading it to the same version.