### PR TITLE
Only emit stopped event when there are no in-flight messages

### DIFF
--- a/dist/consumer.d.ts
+++ b/dist/consumer.d.ts
@@ -47,6 +47,7 @@ export declare class Consumer extends EventEmitter {
     private pollingWaitTimeMs;
     private msDelayOnEmptyBatchSize;
     private terminateVisibilityTimeout;
+    private inFlightMessages;
     private sqs;
     constructor(options: ConsumerOptions);
     readonly isRunning: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "sqs-consumer",
-  "version": "6.2.0",
+  "version": "6.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqs-consumer",
-      "version": "6.2.0",
+      "version": "6.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "aws-sdk": "2.1490.0",
+        "aws-sdk": "2.1489.0",
         "debug": "^4.1.1"
       },
       "devDependencies": {
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1490.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1490.0.tgz",
-      "integrity": "sha512-nRVP1+JVGHytxrPpc+6I41lTILzYeTOBAdNbgCi5bwRPrnEr/DxunyHWbGh92qupfHbm9dFcKdao4pOMPDOcVA==",
+      "version": "2.1489.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1489.0.tgz",
+      "integrity": "sha512-DXps/qhDxnVMoQmMu+HIEd92IlCR5HLGGEMmivBaRkga1uyMBrI1D5glNYjyZMfZS1n7ECpiU6xXa/jyBKZ8Qg==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-consumer",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "Build SQS-based Node applications without the boilerplate",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -134,7 +134,7 @@ describe('Consumer', () => {
 
       consumer.start();
 
-      const err = await pEvent(consumer, 'error');
+      const err = await pEvent(consumer, 'unhandled_error');
 
       consumer.stop();
       assert.ok(err);
@@ -153,7 +153,7 @@ describe('Consumer', () => {
       sqs.receiveMessage = stubReject(receiveErr);
 
       consumer.start();
-      const err = await pEvent(consumer, 'error');
+      const err = await pEvent(consumer, 'unhandled_error');
       consumer.stop();
 
       assert.ok(err);
@@ -264,7 +264,7 @@ describe('Consumer', () => {
           resolve();
         });
 
-        consumer.on('error', errorListener);
+        consumer.on('unhandled_error', errorListener);
         consumer.start();
       });
     });
@@ -287,7 +287,7 @@ describe('Consumer', () => {
           resolve();
         });
 
-        consumer.on('error', errorListener);
+        consumer.on('unhandled_error', errorListener);
         consumer.start();
       });
     });
@@ -310,7 +310,7 @@ describe('Consumer', () => {
           resolve();
         });
 
-        consumer.on('error', errorListener);
+        consumer.on('unhandled_error', errorListener);
         consumer.start();
       });
     });


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/8108880290/views/173703832/pulses/8656995693


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `inFlightMessages` to track active message processing.

- Modified `poll` and message handling logic to emit `stopped` only when no in-flight messages remain.

- Updated error event handling to use `unhandled_error` instead of `error`.

- Bumped package version to 6.4.0.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consumer.d.ts</strong><dd><code>Add `inFlightMessages` property to type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dist/consumer.d.ts

- Added `inFlightMessages` property to the `Consumer` class.


</details>


  </td>
  <td><a href="https://github.com/DaPulse/sqs-consumer/pull/34/files#diff-b231abc0025111a5149326def70e6499915e985a6d48a6e576fef1ee9fabf803">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>consumer.ts</strong><dd><code>Enhance consumer logic to track in-flight messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/consumer.ts

<li>Introduced <code>inFlightMessages</code> to track active message processing.<br> <li> Updated <code>poll</code> to check <code>inFlightMessages</code> before emitting <code>stopped</code>.<br> <li> Adjusted message handling to decrement <code>inFlightMessages</code> and emit <br><code>stopped</code> if appropriate.


</details>


  </td>
  <td><a href="https://github.com/DaPulse/sqs-consumer/pull/34/files#diff-720b6bfe5e0c4c43dcef59d90017b3517a0cfaa675b8f017ecf9e29fabfa48ef">+20/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>consumer.js</strong><dd><code>Implement `inFlightMessages` logic in compiled JavaScript</code></dd></summary>
<hr>

dist/consumer.js

<li>Added <code>inFlightMessages</code> initialization and logic.<br> <li> Updated <code>poll</code> and message handling to respect <code>inFlightMessages</code>.


</details>


  </td>
  <td><a href="https://github.com/DaPulse/sqs-consumer/pull/34/files#diff-37efefc9826d6c86f2dafafaa8cfefd73ad0cd92e1ebac94908e971d80880b60">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consumer.ts</strong><dd><code>Update tests to reflect new error event naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/consumer.ts

<li>Replaced <code>error</code> event assertions with <code>unhandled_error</code>.<br> <li> Updated tests to align with new error event naming.


</details>


  </td>
  <td><a href="https://github.com/DaPulse/sqs-consumer/pull/34/files#diff-9b28f54688f830adc0fa9a64662816d34c24f97f5f88f783b32e051abe80f6a3">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update package version to 6.4.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Bumped version from 6.3.0 to 6.4.0.


</details>


  </td>
  <td><a href="https://github.com/DaPulse/sqs-consumer/pull/34/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>