### PR TITLE
Making `async-comm`s co-owners `CODEOWNERS` of `sqs-consumer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ test.js
 coverage
 # dist
 .nyc_output
+
+# IDE
+.idea

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Set @DaPulse/async-communication as default code owners of all files.
+* @DaPulse/async-communication

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Set @DaPulse/async-communication as default code owners of all files.
-* @DaPulse/async-communication
+* @DaPulse/app-level-infra @DaPulse/async-communication


### PR DESCRIPTION
### **User description**
The Async Comms team is expanding it's ownership within Monday to cover SNS/SQS messaging, which is currently under the ownership of @DaPulse/app-level-infra.

We will take joint ownership of these files for the moment, and then eventually move to sole ownership.

#### Hotfixes

N/A

---

[Monday Board Item Link](https://monday.monday.com/boards/6034327970/pulses/9685506698)


___

### **PR Type**
Other


___

### **Description**
- Add `@DaPulse/async-communication` as default code owners


___

### Diagram Walkthrough


```mermaid
flowchart LR
  repo["Repository"] --> codeowners["CODEOWNERS file"]
  codeowners --> team["@DaPulse/async-communication"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CODEOWNERS</strong><dd><code>Add async-communication team as default owners</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CODEOWNERS

<ul><li>Create new CODEOWNERS file<br> <li> Set @DaPulse/async-communication as default owners for all files</ul>


</details>


  </td>
  <td><a href="https://github.com/DaPulse/sqs-consumer/pull/38/files#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

